### PR TITLE
feat: added decimal scalar.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,18 +91,3 @@ jobs:
 
       - name: Codecov
         uses: codecov/codecov-action@v3.1.1
-
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: [tests]
-    if: ${{ needs.lint.result == 'success' &&
-      needs.tests.result == 'success' &&
-      github.event.action == 'published' }}
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v1.16
-        with:
-          pypi_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-![qt-graphql.png](assets%2Fqt-graphql.png)
 ###  Qt framework for building graphql driven QML applications
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/qtgql?style=for-the-badge)](https://pypi.org/project/qtgql/)
 [![PyPI](https://img.shields.io/pypi/v/qtgql?style=for-the-badge)](https://pypi.org/project/qtgql/)
@@ -6,8 +5,7 @@
 ](https://github.com/nrbnlulu/qtgql/actions/workflows/tests.yml)
 [![Codecov](https://img.shields.io/codecov/c/github/nrbnlulu/qtgql?style=for-the-badge)](https://app.codecov.io/gh/nrbnlulu/qtgql)
 [![Discord](https://img.shields.io/discord/1067870318301032558?label=discord&style=for-the-badge)](https://discord.gg/5vmRRJp9fu)
-[![forthebadge](https://forthebadge.com/images/badges/gluten-free.svg)](https://forthebadge.com)
-[![forthebadge](https://forthebadge.com/images/badges/contains-cat-gifs.svg)](https://forthebadge.com)
+
 
 ### Disclaimer
 This project is currently under development and **it is not** production ready,

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,25 +1,8 @@
 Release type: minor
 
-This release adds datetime scalar support by allowing
-custom scalars. users can now add their own scalars like this:
-
-```python
-from qtgql.codegen.py.scalars import BaseCustomScalar
-from datetime import datetime
-
-class MyDateTime(BaseCustomScalar[datetime]):
-    def to_qt(self) -> str | None:
-        if self._value:
-            return self._value.strftime(' %D:%H:%M: ')
-        return None
-```
-This should be added in QtGqlConfig like so
-
-```python
-from qtgql.codegen.py.config import QtGqlConfig
-my_scalars = {
-    'MyDateTime': MyDateTime  # the key is a valid graphql name of the scalar
-}
-
-qtgqlconfig = QtGqlConfig(url=..., output=..., custom_scalars=my_scalars)
-```
+This release adds support for strawberry builtin scalars
+- Date - an ISO-8601 encoded [date](https://docs.python.org/3/library/datetime.html#date-objects)
+- Time - an ISO-8601 encoded [time](https://docs.python.org/3/library/datetime.html#time-objects)
+- Decimal- a [Decimal](https://docs.python.org/3/library/decimal.html#decimal.Decimal) value serialized as a string
+- UUID -  a [UUID](https://docs.python.org/3/library/uuid.html#uuid.UUID) value serialized as a string
+- VOID -  always null, maps to Python’s None

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,4 +5,3 @@ This release adds support for strawberry builtin scalars
 - Time - an ISO-8601 encoded [time](https://docs.python.org/3/library/datetime.html#time-objects)
 - Decimal- a [Decimal](https://docs.python.org/3/library/decimal.html#decimal.Decimal) value serialized as a string
 - UUID -  a [UUID](https://docs.python.org/3/library/uuid.html#uuid.UUID) value serialized as a string
-- VOID -  always null, maps to Python’s None

--- a/docs/codegen/scalars/create_scalar.md
+++ b/docs/codegen/scalars/create_scalar.md
@@ -1,6 +1,8 @@
-# Custom scalars
 
-### Intro
+# Create Your own custom scalar
+Although **QtGQL** provides some [frequently used scalars](./custom_scalars.md), you might have your own complex scalars.
+
+## Tutorial - Country scalar
 In order to deserialize a scalar for it to be compatible with Qt we created
 `BaseCustomScalar`. For example if you have a scalar of country code, you want to show the user a readable value.
 
@@ -38,6 +40,6 @@ assert CountryCode.from_graphql('isr').to_qt() == 'israel'
     QtGqlConfig(custom_scalars={CountryCode.GRAPHQL_NAME: CountryCode}, ...)
     ```
 
-### API
+## API
 
 ::: qtgql.codegen.py.scalars

--- a/docs/codegen/scalars/custom_scalars.md
+++ b/docs/codegen/scalars/custom_scalars.md
@@ -1,0 +1,7 @@
+
+# Custom scalars
+**QtGQL** provides some custom scalars by default, they are intended to be comatible with
+[Strawberry-GraphQL](https://strawberry.rocks/docs/types/scalars#scalars) custom scalars,
+though you can override them.
+
+::: qtgql.codegen.py.custom_scalars

--- a/docs/codegen/scalars/index.md
+++ b/docs/codegen/scalars/index.md
@@ -13,8 +13,9 @@ scalars since we won't modify the value came from the `json` response.
 - `ID`, a specialised `String` for representing unique object identifiers
 - `UUID`, maps to Python’s `str`
 
-!!! Note "UUID"
+!!! Note "UUID scalar"
     Although you could expect of UUID to map to [Python's UUID](https://docs.python.org/3/library/uuid.html#uuid.UUID)
     Since it would come with performance penalty and the advantages are nominal, we decided to stick with a no-op scalar.
+
 
 [//]: # (# TODO: add note about uuid)

--- a/docs/codegen/scalars/index.md
+++ b/docs/codegen/scalars/index.md
@@ -1,0 +1,14 @@
+# Scalars
+
+The GraphQL specification includes default scalar types Int, Float, String, Boolean, and ID. Although these scalars cover the majority of use cases, some applications need to support other atomic data types (such as Date) or add validation to an existing type. To enable this, you can define custom scalar types.
+
+## Builtin scalars
+These scalars are represented by a Python "builtin" type
+
+- `String`, maps to Python’s `str`
+- `Int`, a signed 32-bit integer, maps to Python’s `int`
+- `Float`, a signed double-precision floating-point value, maps to Python’s `float`
+- `Boolean`, true or false, maps to Python’s `bool`
+- `ID`, a specialised `String` for representing unique object identifiers
+
+[//]: # (# TODO: add note about uuid)

--- a/docs/codegen/scalars/index.md
+++ b/docs/codegen/scalars/index.md
@@ -3,12 +3,18 @@
 The GraphQL specification includes default scalar types Int, Float, String, Boolean, and ID. Although these scalars cover the majority of use cases, some applications need to support other atomic data types (such as Date) or add validation to an existing type. To enable this, you can define custom scalar types.
 
 ## Builtin scalars
-These scalars are represented by a Python "builtin" type
+These scalars are represented by a Python "builtin" type, These are basically "no-op"
+scalars since we won't modify the value came from the `json` response.
 
 - `String`, maps to Python’s `str`
 - `Int`, a signed 32-bit integer, maps to Python’s `int`
 - `Float`, a signed double-precision floating-point value, maps to Python’s `float`
 - `Boolean`, true or false, maps to Python’s `bool`
 - `ID`, a specialised `String` for representing unique object identifiers
+- `UUID`, maps to Python’s `str`
+
+!!! Note "UUID"
+    Although you could expect of UUID to map to [Python's UUID](https://docs.python.org/3/library/uuid.html#uuid.UUID)
+    Since it would come with performance penalty and the advantages are nominal, we decided to stick with a no-op scalar.
 
 [//]: # (# TODO: add note about uuid)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,10 @@ nav:
       - Utils: ./utilities.md
   - Codegen:
       Tutorial: ./codegen/tutorial.md
-      Custom scalars: ./codegen/custom_scalar.md
+      Scalars:
+        - Index: ./codegen/scalars/index.md
+        - Custom Scalars: ./codegen/scalars/custom_scalars.md
+        - Create a Scalar: ./codegen/scalars/create_scalar.md
   - ItemSystem:
       Intro: ./itemsystem/intro.md
 markdown_extensions:

--- a/qtgql/codegen/introspection.py
+++ b/qtgql/codegen/introspection.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING, Optional, Union
 import graphql
 
 from qtgql.codegen.py.compiler import TemplateContext
+from qtgql.codegen.py.custom_scalars import CUSTOM_SCALARS
 from qtgql.codegen.py.objecttype import FieldProperty, GqlType, Kinds
-from qtgql.codegen.py.scalars import CUSTOM_SCALARS, BuiltinScalars
+from qtgql.codegen.py.scalars import BuiltinScalars
 from qtgql.codegen.utils import anti_forward_ref
 from qtgql.typingref import TypeHinter
 

--- a/qtgql/codegen/py/config.py
+++ b/qtgql/codegen/py/config.py
@@ -7,7 +7,7 @@ from attrs import define
 from qtgql.codegen.introspection import SchemaEvaluator, introspection_query
 from qtgql.codegen.py.bases import BaseGraphQLObject, _BaseQGraphQLObject
 from qtgql.codegen.py.compiler import TemplateContext, py_template
-from qtgql.codegen.py.scalars import CUSTOM_SCALARS, CustomScalarMap
+from qtgql.codegen.py.custom_scalars import CUSTOM_SCALARS, CustomScalarMap
 
 
 @define

--- a/qtgql/codegen/py/custom_scalars.py
+++ b/qtgql/codegen/py/custom_scalars.py
@@ -1,0 +1,65 @@
+from datetime import date, datetime
+from typing import Optional, Type
+
+from _decimal import Decimal
+
+from qtgql.codegen.py.scalars import BaseCustomScalar
+
+
+class DateTimeScalar(BaseCustomScalar[Optional[datetime]]):
+    """An ISO-8601 encoded datetime."""
+
+    GRAPHQL_NAME: str = "DateTime"
+    DEFAULT_DESERIALIZED = " --- "
+
+    @classmethod
+    def from_graphql(cls, v: Optional[str] = None) -> "DateTimeScalar":
+        if v:
+            return cls(datetime.fromisoformat(v))
+        return cls(None)
+
+    def to_qt(self) -> str:
+        if self._value:
+            return self._value.strftime(" %H:%M: ")
+        return self.DEFAULT_DESERIALIZED
+
+
+class DecimalScalar(BaseCustomScalar[Decimal]):
+    """A Decimal value serialized as a string."""
+
+    GRAPHQL_NAME = "Decimal"
+    DEFAULT_DESERIALIZED = Decimal()
+
+    @classmethod
+    def from_graphql(cls, v: Optional[str] = None) -> "DecimalScalar":
+        if v:
+            return cls(Decimal(v))
+        return cls(cls.DEFAULT_DESERIALIZED)
+
+    def to_qt(self) -> str:
+        return str(self._value)
+
+
+class DateScalar(BaseCustomScalar[Optional[date]]):
+    """An ISO-8601 encoded date."""
+
+    GRAPHQL_NAME = "Date"
+
+    @classmethod
+    def from_graphql(cls, v: Optional[str] = None) -> "DateScalar":
+        if v:
+            return cls(date.fromisoformat(v))
+        return cls(None)
+
+    def to_qt(self) -> str:
+        if self._value:
+            return self._value.isoformat()
+        return self.DEFAULT_DESERIALIZED
+
+
+CustomScalarMap = dict[str, Type[BaseCustomScalar]]
+CUSTOM_SCALARS: CustomScalarMap = {
+    DateTimeScalar.GRAPHQL_NAME: DateTimeScalar,
+    DecimalScalar.GRAPHQL_NAME: DecimalScalar,
+    DateScalar.GRAPHQL_NAME: DateScalar,
+}

--- a/qtgql/codegen/py/custom_scalars.py
+++ b/qtgql/codegen/py/custom_scalars.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, time
 from typing import Optional, Type
 
 from _decimal import Decimal
@@ -24,22 +24,6 @@ class DateTimeScalar(BaseCustomScalar[Optional[datetime]]):
         return self.DEFAULT_DESERIALIZED
 
 
-class DecimalScalar(BaseCustomScalar[Decimal]):
-    """A Decimal value serialized as a string."""
-
-    GRAPHQL_NAME = "Decimal"
-    DEFAULT_DESERIALIZED = Decimal()
-
-    @classmethod
-    def from_graphql(cls, v: Optional[str] = None) -> "DecimalScalar":
-        if v:
-            return cls(Decimal(v))
-        return cls(cls.DEFAULT_DESERIALIZED)
-
-    def to_qt(self) -> str:
-        return str(self._value)
-
-
 class DateScalar(BaseCustomScalar[Optional[date]]):
     """An ISO-8601 encoded date."""
 
@@ -57,9 +41,43 @@ class DateScalar(BaseCustomScalar[Optional[date]]):
         return self.DEFAULT_DESERIALIZED
 
 
+class TimeScalar(BaseCustomScalar[Optional[time]]):
+    """an ISO-8601 encoded time."""
+
+    GRAPHQL_NAME = "Time"
+
+    @classmethod
+    def from_graphql(cls, v: Optional[str] = None) -> "TimeScalar":
+        if v:
+            return cls(time.fromisoformat(v))
+        return cls(None)
+
+    def to_qt(self) -> str:
+        if self._value:
+            return self._value.isoformat()
+        return self.DEFAULT_DESERIALIZED
+
+
+class DecimalScalar(BaseCustomScalar[Decimal]):
+    """A Decimal value serialized as a string."""
+
+    GRAPHQL_NAME = "Decimal"
+    DEFAULT_DESERIALIZED = Decimal()
+
+    @classmethod
+    def from_graphql(cls, v: Optional[str] = None) -> "DecimalScalar":
+        if v:
+            return cls(Decimal(v))
+        return cls(cls.DEFAULT_DESERIALIZED)
+
+    def to_qt(self) -> str:
+        return str(self._value)
+
+
 CustomScalarMap = dict[str, Type[BaseCustomScalar]]
 CUSTOM_SCALARS: CustomScalarMap = {
     DateTimeScalar.GRAPHQL_NAME: DateTimeScalar,
     DecimalScalar.GRAPHQL_NAME: DecimalScalar,
     DateScalar.GRAPHQL_NAME: DateScalar,
+    TimeScalar.GRAPHQL_NAME: TimeScalar,
 }

--- a/qtgql/codegen/py/objecttype.py
+++ b/qtgql/codegen/py/objecttype.py
@@ -5,7 +5,8 @@ from typing import List, Optional, Type, Union
 from attrs import define
 
 from qtgql.codegen.py.bases import _BaseQGraphQLObject
-from qtgql.codegen.py.scalars import BaseCustomScalar, BuiltinScalars, CustomScalarMap
+from qtgql.codegen.py.custom_scalars import CustomScalarMap
+from qtgql.codegen.py.scalars import BaseCustomScalar, BuiltinScalars
 from qtgql.codegen.utils import AntiForwardRef
 from qtgql.typingref import TypeHinter
 

--- a/qtgql/codegen/py/scalars.py
+++ b/qtgql/codegen/py/scalars.py
@@ -1,10 +1,8 @@
-from datetime import date, datetime
-from decimal import Decimal
-from typing import Any, Generic, Optional, Type, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 T = TypeVar("T")
 
-__all__ = ["BaseCustomScalar", "DateTimeScalar", "BuiltinScalars", "CUSTOM_SCALARS"]
+__all__ = ["BaseCustomScalar", "BuiltinScalars"]
 
 
 class BaseCustomScalar(Generic[T]):
@@ -40,65 +38,6 @@ class BaseCustomScalar(Generic[T]):
         """
         raise NotImplementedError  # pragma: no cover
 
-
-class DateTimeScalar(BaseCustomScalar[Optional[datetime]]):
-    """An ISO-8601 encoded datetime."""
-
-    GRAPHQL_NAME: str = "DateTime"
-    DEFAULT_DESERIALIZED = " --- "
-
-    @classmethod
-    def from_graphql(cls, v: Optional[str] = None) -> "DateTimeScalar":
-        if v:
-            return cls(datetime.fromisoformat(v))
-        return cls(None)
-
-    def to_qt(self) -> str:
-        if self._value:
-            return self._value.strftime(" %H:%M: ")
-        return self.DEFAULT_DESERIALIZED
-
-
-class DecimalScalar(BaseCustomScalar[Decimal]):
-    """A Decimal value serialized as a string."""
-
-    GRAPHQL_NAME = "Decimal"
-    DEFAULT_DESERIALIZED = Decimal()
-
-    @classmethod
-    def from_graphql(cls, v: Optional[str] = None) -> "DecimalScalar":
-        if v:
-            return cls(Decimal(v))
-        return cls(cls.DEFAULT_DESERIALIZED)
-
-    def to_qt(self) -> str:
-        return str(self._value)
-
-
-class DateScalar(BaseCustomScalar[Optional[date]]):
-    """An ISO-8601 encoded date."""
-
-    GRAPHQL_NAME = "Date"
-
-    @classmethod
-    def from_graphql(cls, v: Optional[str] = None) -> "DateScalar":
-        if v:
-            return cls(date.fromisoformat(v))
-        return cls(None)
-
-    def to_qt(self) -> str:
-        if self._value:
-            return self._value.isoformat()
-        return self.DEFAULT_DESERIALIZED
-
-
-CustomScalarMap = dict[str, Type[BaseCustomScalar]]
-
-CUSTOM_SCALARS: CustomScalarMap = {
-    DateTimeScalar.GRAPHQL_NAME: DateTimeScalar,
-    DecimalScalar.GRAPHQL_NAME: DecimalScalar,
-    DateScalar.GRAPHQL_NAME: DateScalar,
-}
 
 BuiltinScalars: dict[str, type] = {
     "Int": int,

--- a/qtgql/codegen/py/scalars.py
+++ b/qtgql/codegen/py/scalars.py
@@ -45,4 +45,5 @@ BuiltinScalars: dict[str, type] = {
     "String": str,
     "ID": str,
     "Boolean": bool,
+    "UUID": str,
 }

--- a/tests/test_codegen/schemas/__init__.py
+++ b/tests/test_codegen/schemas/__init__.py
@@ -9,6 +9,7 @@ from . import (
     object_with_optional_object,
     object_with_optional_scalar,
     object_with_scalar,
+    object_with_time_scalar,
     object_with_union,
 )
 
@@ -24,4 +25,5 @@ __all__ = [
     object_with_datetime,
     object_with_decimal,
     object_with_date,
+    object_with_time_scalar,
 ]

--- a/tests/test_codegen/schemas/__init__.py
+++ b/tests/test_codegen/schemas/__init__.py
@@ -1,4 +1,5 @@
 from . import (
+    object_with_date,
     object_with_datetime,
     object_with_decimal,
     object_with_interface,
@@ -22,4 +23,5 @@ __all__ = [
     object_with_list_of_type_with_union,
     object_with_datetime,
     object_with_decimal,
+    object_with_date,
 ]

--- a/tests/test_codegen/schemas/__init__.py
+++ b/tests/test_codegen/schemas/__init__.py
@@ -1,5 +1,6 @@
 from . import (
     object_with_datetime,
+    object_with_decimal,
     object_with_interface,
     object_with_list_of_object,
     object_with_list_of_type_with_union,
@@ -20,4 +21,5 @@ __all__ = [
     object_with_union,
     object_with_list_of_type_with_union,
     object_with_datetime,
+    object_with_decimal,
 ]

--- a/tests/test_codegen/schemas/object_with_date.py
+++ b/tests/test_codegen/schemas/object_with_date.py
@@ -1,0 +1,20 @@
+from datetime import date
+
+import strawberry
+
+
+@strawberry.type
+class User:
+    name: str
+    age: int
+    birth: date
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user(self) -> User:
+        return User(name="Patrick", age=100, birth=date.today())
+
+
+schema = strawberry.Schema(query=Query)

--- a/tests/test_codegen/schemas/object_with_decimal.py
+++ b/tests/test_codegen/schemas/object_with_decimal.py
@@ -1,0 +1,20 @@
+from decimal import Decimal
+
+import strawberry
+
+
+@strawberry.type
+class User:
+    name: str
+    age: int
+    balance: Decimal
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user(self) -> User:
+        return User(name="Patrick", age=100, balance=Decimal(10000000.0))
+
+
+schema = strawberry.Schema(query=Query)

--- a/tests/test_codegen/schemas/object_with_scalar.py
+++ b/tests/test_codegen/schemas/object_with_scalar.py
@@ -1,3 +1,6 @@
+import uuid
+from uuid import UUID
+
 import strawberry
 
 
@@ -8,13 +11,21 @@ class User:
     age_point: float
     male: bool
     id: strawberry.ID
+    uuid: UUID
 
 
 @strawberry.type
 class Query:
     @strawberry.field
     def user(self) -> User:
-        return User(name="Patrick", age=100, age_point=100.0, male=True, id=strawberry.ID("unique"))
+        return User(
+            name="Patrick",
+            age=100,
+            age_point=100.0,
+            male=True,
+            id=strawberry.ID("unique"),
+            uuid=uuid.uuid4(),
+        )
 
 
 schema = strawberry.Schema(query=Query)

--- a/tests/test_codegen/schemas/object_with_time_scalar.py
+++ b/tests/test_codegen/schemas/object_with_time_scalar.py
@@ -1,0 +1,20 @@
+from datetime import datetime, time
+
+import strawberry
+
+
+@strawberry.type
+class User:
+    name: str
+    age: int
+    whatTimeIsIt: time
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user(self) -> User:
+        return User(name="Patrick", age=100, whatTimeIsIt=datetime.now().time())
+
+
+schema = strawberry.Schema(query=Query)

--- a/tests/test_codegen/test_py/__temp.py
+++ b/tests/test_codegen/test_py/__temp.py
@@ -5,7 +5,7 @@ from typing import Optional
 from PySide6.QtCore import QObject, Signal
 from qtgql import qproperty
 from qtgql.codegen.py.bases import BaseGraphQLObject, BaseModel
-from qtgql.codegen.py.scalars import DateTimeScalar
+from qtgql.codegen.py.custom_scalars import DateTimeScalar
 
 
 class SCALARS:

--- a/tests/test_codegen/test_py/test_introspection_generator.py
+++ b/tests/test_codegen/test_py/test_introspection_generator.py
@@ -10,7 +10,7 @@ from attr import define
 from qtgql.codegen.introspection import SchemaEvaluator, introspection_query
 from qtgql.codegen.py.bases import BaseModel, _BaseQGraphQLObject
 from qtgql.codegen.py.config import QtGqlConfig
-from qtgql.codegen.py.custom_scalars import DateScalar, DateTimeScalar, DecimalScalar
+from qtgql.codegen.py.custom_scalars import DateScalar, DateTimeScalar, DecimalScalar, TimeScalar
 from qtgql.codegen.py.objecttype import GqlType
 from qtgql.codegen.py.scalars import BaseCustomScalar, BuiltinScalars
 from qtgql.typingref import TypeHinter
@@ -298,6 +298,20 @@ DateTestCase = QGQLObjectTestCase(
     test_name="DateTestCase",
 )
 
+TimeTestCase = QGQLObjectTestCase(
+    schema=schemas.object_with_time_scalar.schema,
+    query="""
+        {
+          user {
+            name
+            age
+            whatTimeIsIt
+          }
+        }
+        """,
+    test_name="TimeTestCase",
+)
+
 all_test_cases = [
     ScalarsTestCase,
     DateTimeTestCase,
@@ -310,12 +324,14 @@ all_test_cases = [
     InterfaceTestCase,
     UnionTestCase,
     ListOfUnionTestCase,
+    TimeTestCase,
 ]
 
 custom_scalar_testcases = [
     (DateTimeTestCase, DateTimeScalar, "birth"),
     (DateTestCase, DateScalar, "birth"),
     (DecimalTestCase, DecimalScalar, "balance"),
+    (TimeTestCase, TimeScalar, "whatTimeIsIt"),
 ]
 
 

--- a/tests/test_codegen/test_py/test_introspection_generator.py
+++ b/tests/test_codegen/test_py/test_introspection_generator.py
@@ -11,7 +11,13 @@ from qtgql.codegen.introspection import SchemaEvaluator, introspection_query
 from qtgql.codegen.py.bases import BaseModel, _BaseQGraphQLObject
 from qtgql.codegen.py.config import QtGqlConfig
 from qtgql.codegen.py.objecttype import GqlType
-from qtgql.codegen.py.scalars import BaseCustomScalar, BuiltinScalars, DateTimeScalar, DecimalScalar
+from qtgql.codegen.py.scalars import (
+    BaseCustomScalar,
+    BuiltinScalars,
+    DateScalar,
+    DateTimeScalar,
+    DecimalScalar,
+)
 from qtgql.typingref import TypeHinter
 from strawberry import Schema
 
@@ -279,12 +285,28 @@ DecimalTestCase = QGQLObjectTestCase(
           }
         }
     """,
-    test_name="DateTimeTestCase",
+    test_name="DecimalTestCase",
+)
+
+DateTestCase = QGQLObjectTestCase(
+    schema=schemas.object_with_date.schema,
+    query="""
+        {
+          user {
+            name
+            age
+            birth
+          }
+        }
+        """,
+    test_name="DateTestCase",
 )
 
 all_test_cases = [
     ScalarsTestCase,
     DateTimeTestCase,
+    DateTestCase,
+    DecimalTestCase,
     OptionalScalarTestCase,
     NestedObjectTestCase,
     OptionalNestedObjectTestCase,
@@ -296,6 +318,7 @@ all_test_cases = [
 
 custom_scalar_testcases = [
     (DateTimeTestCase, DateTimeScalar, "birth"),
+    (DateTestCase, DateScalar, "birth"),
     (DecimalTestCase, DecimalScalar, "balance"),
 ]
 

--- a/tests/test_codegen/test_py/test_introspection_generator.py
+++ b/tests/test_codegen/test_py/test_introspection_generator.py
@@ -10,14 +10,9 @@ from attr import define
 from qtgql.codegen.introspection import SchemaEvaluator, introspection_query
 from qtgql.codegen.py.bases import BaseModel, _BaseQGraphQLObject
 from qtgql.codegen.py.config import QtGqlConfig
+from qtgql.codegen.py.custom_scalars import DateScalar, DateTimeScalar, DecimalScalar
 from qtgql.codegen.py.objecttype import GqlType
-from qtgql.codegen.py.scalars import (
-    BaseCustomScalar,
-    BuiltinScalars,
-    DateScalar,
-    DateTimeScalar,
-    DecimalScalar,
-)
+from qtgql.codegen.py.scalars import BaseCustomScalar, BuiltinScalars
 from qtgql.typingref import TypeHinter
 from strawberry import Schema
 

--- a/tests/test_codegen/test_py/test_introspection_generator.py
+++ b/tests/test_codegen/test_py/test_introspection_generator.py
@@ -127,6 +127,7 @@ ScalarsTestCase = QGQLObjectTestCase(
             agePoint
             male
             id
+            uuid
           }
         }
         """,

--- a/tests/test_codegen/test_py/test_scalars.py
+++ b/tests/test_codegen/test_py/test_scalars.py
@@ -3,7 +3,8 @@ from datetime import date
 from decimal import Decimal
 from typing import Type
 
-from qtgql.codegen.py.scalars import BaseCustomScalar, DateScalar, DecimalScalar
+from qtgql.codegen.py.custom_scalars import DateScalar, DecimalScalar
+from qtgql.codegen.py.scalars import BaseCustomScalar
 
 
 class AbstractScalarTestCase(ABC):

--- a/tests/test_codegen/test_py/test_scalars.py
+++ b/tests/test_codegen/test_py/test_scalars.py
@@ -1,0 +1,34 @@
+from abc import ABC, abstractmethod
+from decimal import Decimal
+
+from qtgql.codegen.py.scalars import DecimalScalar
+
+
+class AbstractScalarTestCase(ABC):
+    @abstractmethod
+    def test_deserialize(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def test_to_qt(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def test_default_value(self):
+        raise NotImplementedError
+
+
+class TestDecimalScalar(AbstractScalarTestCase):
+    def test_deserialize(self):
+        expected = Decimal(1000)
+        scalar = DecimalScalar.from_graphql(str(expected))
+        assert scalar._value == expected
+
+    def test_to_qt(self):
+        scalar = DecimalScalar.from_graphql("100.0")
+        assert scalar.to_qt() == "100.0"
+
+    def test_default_value(self):
+        scalar = DecimalScalar.from_graphql()
+        assert scalar._value == Decimal()
+        assert scalar.to_qt() == "0"

--- a/tests/test_codegen/test_py/test_scalars.py
+++ b/tests/test_codegen/test_py/test_scalars.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
-from datetime import date
+from datetime import date, datetime, time
 from decimal import Decimal
 from typing import Type
 
-from qtgql.codegen.py.custom_scalars import DateScalar, DecimalScalar
+from qtgql.codegen.py.custom_scalars import DateScalar, DecimalScalar, TimeScalar
 from qtgql.codegen.py.scalars import BaseCustomScalar
 
 
@@ -51,3 +51,17 @@ class TestDateScalar(AbstractScalarTestCase):
     def test_to_qt(self):
         scalar = DateScalar(date.today())
         assert scalar.to_qt() == date.today().isoformat()
+
+
+class TestTimeScalar(AbstractScalarTestCase):
+    scalar_klass = TimeScalar
+
+    def test_deserialize(self):
+        expected: time = datetime.now().time()
+        scalar = TimeScalar.from_graphql(expected.isoformat())
+        assert scalar._value == expected
+
+    def test_to_qt(self):
+        now = datetime.now().time()
+        scalar = TimeScalar(now)
+        assert scalar.to_qt() == now.isoformat()

--- a/tests/test_sample_ui/__temp.py
+++ b/tests/test_sample_ui/__temp.py
@@ -5,11 +5,13 @@ from typing import Optional
 from PySide6.QtCore import QObject, Signal
 from qtgql import qproperty
 from qtgql.codegen.py.bases import BaseGraphQLObject, BaseModel
-from qtgql.codegen.py.scalars import DateTimeScalar
+from qtgql.codegen.py.scalars import DateTimeScalar, DecimalScalar
 
 
 class SCALARS:
     DateTimeScalar = DateTimeScalar
+
+    DecimalScalar = DecimalScalar
 
 
 class Query(BaseGraphQLObject):

--- a/tests/test_sample_ui/__temp.py
+++ b/tests/test_sample_ui/__temp.py
@@ -5,7 +5,7 @@ from typing import Optional
 from PySide6.QtCore import QObject, Signal
 from qtgql import qproperty
 from qtgql.codegen.py.bases import BaseGraphQLObject, BaseModel
-from qtgql.codegen.py.scalars import DateScalar, DateTimeScalar, DecimalScalar
+from qtgql.codegen.py.custom_scalars import DateScalar, DateTimeScalar, DecimalScalar
 
 
 class SCALARS:

--- a/tests/test_sample_ui/__temp.py
+++ b/tests/test_sample_ui/__temp.py
@@ -5,13 +5,15 @@ from typing import Optional
 from PySide6.QtCore import QObject, Signal
 from qtgql import qproperty
 from qtgql.codegen.py.bases import BaseGraphQLObject, BaseModel
-from qtgql.codegen.py.scalars import DateTimeScalar, DecimalScalar
+from qtgql.codegen.py.scalars import DateScalar, DateTimeScalar, DecimalScalar
 
 
 class SCALARS:
     DateTimeScalar = DateTimeScalar
 
     DecimalScalar = DecimalScalar
+
+    DateScalar = DateScalar
 
 
 class Query(BaseGraphQLObject):

--- a/tests/test_sample_ui/__temp.py
+++ b/tests/test_sample_ui/__temp.py
@@ -5,7 +5,7 @@ from typing import Optional
 from PySide6.QtCore import QObject, Signal
 from qtgql import qproperty
 from qtgql.codegen.py.bases import BaseGraphQLObject, BaseModel
-from qtgql.codegen.py.custom_scalars import DateScalar, DateTimeScalar, DecimalScalar
+from qtgql.codegen.py.custom_scalars import DateScalar, DateTimeScalar, DecimalScalar, TimeScalar
 
 
 class SCALARS:
@@ -14,6 +14,8 @@ class SCALARS:
     DecimalScalar = DecimalScalar
 
     DateScalar = DateScalar
+
+    TimeScalar = TimeScalar
 
 
 class Query(BaseGraphQLObject):


### PR DESCRIPTION
closes #43 

- [x] Date - an ISO-8601 encoded [date](https://docs.python.org/3/library/datetime.html#date-objects)
- [x] Time - an ISO-8601 encoded [time](https://docs.python.org/3/library/datetime.html#time-objects)
- [x] Decimal- a [Decimal](https://docs.python.org/3/library/decimal.html#decimal.Decimal) value serialized as a string
- [x] UUID -  a [UUID](https://docs.python.org/3/library/uuid.html#uuid.UUID) value serialized as a string
- [ ] <s> VOID -  always null, maps to Python’s None </s> - won't fix. couldn't find a worth implementing usecase.